### PR TITLE
either upper or lowercase letter support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,7 @@ Optional:
         PASSWORD_COMPLEXITY = { # You can omit any or all of these for no limit for that particular set
             "UPPER": 1,        # Uppercase
             "LOWER": 1,        # Lowercase
+            "LETTERS": 1,       # Either uppercase or lowercase letters
             "DIGITS": 1,       # Digits
             "PUNCTUATION": 1,  # Punctuation (string.punctuation)
             "SPECIAL": 1,      # Not alphanumeric, space or punctuation character

--- a/passwords/validators.py
+++ b/passwords/validators.py
@@ -73,14 +73,16 @@ class ComplexityValidator(object):
         if self.complexities is None:
             return
 
-        uppercase, lowercase, digits = set(), set(), set()
-        special, punctuation = set(), set()
+        uppercase, lowercase, letters = set(), set(), set()
+        digits, special, punctuation = set(), set(), set()
 
         for character in value:
             if character.isupper():
                 uppercase.add(character)
+                letters.add(character)
             elif character.islower():
                 lowercase.add(character)
+                letters.add(character)
             elif character.isdigit():
                 digits.add(character)
             elif character in string.punctuation:
@@ -98,6 +100,10 @@ class ComplexityValidator(object):
         if len(lowercase) < self.complexities.get("LOWER", 0):
             errors.append(
                 _("must contain %(LOWER)s or more unique lowercase characters") %
+                self.complexities)
+        if len(letters) < self.complexities.get("LETTERS", 0):
+            errors.append(
+                _("must contain %(LETTERS)s or more unique letters") %
                 self.complexities)
         if len(digits) < self.complexities.get("DIGITS", 0):
             errors.append(

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -109,6 +109,22 @@ class ComplexityValidatorTests(ValidatorTestCase):
         self.assertInvalid(cv, 'sOME lOWERCASE', 'lowercase')
         self.assertInvalid(cv, 'all lowercase', 'lowercase')
 
+    def test_minimum_letter_count(self):
+        cv = self.mkvalidator(LETTERS=0)
+        self.assertValid(cv, '1234. ?')
+        self.assertValid(cv, 'soME 123')
+        self.assertValid(cv, 'allletters')
+
+        cv = self.mkvalidator(LETTERS=1)
+        self.assertInvalid(cv, '1234. ?', 'letter')
+        self.assertValid(cv, 'soME 123')
+        self.assertValid(cv, 'allletters')
+
+        cv = self.mkvalidator(LETTERS=100)
+        self.assertInvalid(cv, '1234. ?', 'letter')
+        self.assertInvalid(cv, 'soME 123', 'letter')
+        self.assertInvalid(cv, 'allletters', 'letter')
+
     def test_minimum_digit_count(self):
         cv = self.mkvalidator(DIGITS=0)
         self.assertValid(cv, '')

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py27-dj{12,13,14,15,16,17,18a1},
-    py{27,34}-dj{15,16,17,18a1}
+    py27-dj{12,13,14,15,16,17,18},
+    py{27,34}-dj{15,16,17,18}
 
 [testenv]
 commands = py.test tests
@@ -13,4 +13,4 @@ deps =
     dj15: Django>=1.5,<1.6
     dj16: Django>=1.6,<1.7
     dj17: Django>=1.7,<1.8
-    dj18a1: https://www.djangoproject.com/download/1.8a1/tarball/
+    dj18: Django>=1.8,<1.9


### PR DESCRIPTION
It's common to request for example "at least one letter and at least one number" without specifying whether the letter be upper or lower case. 

This PR adds support for requiring a number of **either** upper or lower case letters in a password.

I've also taken the liberty of updating `tox.ini`to reflect the release of dj 1.8.

Tests are failing on `test_minimum_nonascii_count` line 163 but that's not related to this change, the tests for this pass.