### PR TITLE
Formatted password validation failure messages

### DIFF
--- a/passwords/validators.py
+++ b/passwords/validators.py
@@ -95,35 +95,35 @@ class ComplexityValidator(object):
         errors = []
         if len(uppercase) < self.complexities.get("UPPER", 0):
             errors.append(
-                _("must contain %(UPPER)s or more unique uppercase characters") %
+                _("%(UPPER)s or more unique uppercase characters") %
                 self.complexities)
         if len(lowercase) < self.complexities.get("LOWER", 0):
             errors.append(
-                _("must contain %(LOWER)s or more unique lowercase characters") %
+                _("%(LOWER)s or more unique lowercase characters") %
                 self.complexities)
         if len(letters) < self.complexities.get("LETTERS", 0):
             errors.append(
-                _("must contain %(LETTERS)s or more unique letters") %
+                _("%(LETTERS)s or more unique letters") %
                 self.complexities)
         if len(digits) < self.complexities.get("DIGITS", 0):
             errors.append(
-                _("must contain %(DIGITS)s or more unique digits") %
+                _("%(DIGITS)s or more unique digits") %
                 self.complexities)
         if len(punctuation) < self.complexities.get("PUNCTUATION", 0):
             errors.append(
-                (_("must contain %(PUNCTUATION)s or more unique punctuation characters: %%s"
+                (_("%(PUNCTUATION)s or more unique punctuation characters: %%s"
                   ) % self.complexities) % string.punctuation)
         if len(special) < self.complexities.get("SPECIAL", 0):
             errors.append(
-                _("must contain %(SPECIAL)s or more non unique special characters") %
+                _("%(SPECIAL)s or more non unique special characters") %
                 self.complexities)
         if len(words) < self.complexities.get("WORDS", 0):
             errors.append(
-                _("must contain %(WORDS)s or more unique words") %
+                _("%(WORDS)s or more unique words") %
                 self.complexities)
 
         if errors:
-            raise ValidationError(self.message % (u', '.join(errors),),
+            raise ValidationError(self.message % (u'must contain ' + u', '.join(errors),),
                                   code=self.code)
 
 


### PR DESCRIPTION
Hi! Thanks for useful lib!

I removed redundant phrases 'must contain' in error messages that occur when password is not valid by multiple criteria.