### PR TITLE
WIP: add a wrapper for the AUTH_PASSWORD_VALIDATORS API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,3 +125,17 @@ configurations:
             DIGITS=1
         )),
     ])
+
+
+Django's `password validation API`_ is slightly different than the form
+validation API and has wrappers in the `auth_password_validators` module:
+
+.. code-block:: python
+
+    AUTH_PASSWORD_VALIDATORS = [
+        …,
+        {"NAME": "passwords.auth_password_validators.ComplexityValidator"}
+    ]
+
+
+.. _`password validation API`: https://docs.djangoproject.com/en/2.1/topics/auth/passwords/#password-validation

--- a/passwords/auth_password_validators.py
+++ b/passwords/auth_password_validators.py
@@ -1,0 +1,19 @@
+from django.conf import settings
+from django.utils.translation import ugettext_lazy as _
+from . import validators
+
+
+class ComplexityValidator(object):
+    """
+    Wrapper for validators.ComplexityValidator which is compatible
+    with the Django 1.9+ password validation API
+    """
+
+    def __init__(self):
+        self.validator = validators.ComplexityValidator(settings.PASSWORD_COMPLEXITY)
+
+    def get_help_text(self):
+        return _("Your password fails to meet our complexity requirements.")
+
+    def validate(self, value, user=None):
+        return self.validator(value)


### PR DESCRIPTION
This allows validators.ComplexityValidator to be used as a contrib.auth password validator.

Open Questions:
* I'm not in love with the `auth_password_validators` module naming but didn't come up one I like more
* I'm mixed on whether to rely on the namespacing to distinguish classes with the same name in both modules or to add a prefix like `Auth` to the new ones. Since it's only generally used in the settings file the redundancy doesn't seem useful.

