### PR TITLE
Add simple dict cacheing for small dicts

### DIFF
--- a/passwords/validators.py
+++ b/passwords/validators.py
@@ -26,6 +26,9 @@ COMMON_SEQUENCES = [
     "qwertzuiopü*asdfghjklöä'>yxcvbnm;:_",
     "qaywsxedcrfvtgbzhnujmikolp",
 ]
+DICT_CACHE = []
+DICT_FILESIZE = -1
+DICT_MAX_CACHE = 1000000
 
 # Settings
 PASSWORD_MIN_LENGTH = getattr(
@@ -179,6 +182,17 @@ class DictionaryValidator(BaseSimilarityValidator):
             threshold=threshold)
 
     def get_dictionary_words(self, dictionary):
+        if DICT_CACHE:
+            return DICT_CACHE
+        if DICT_FILESIZE is -1:
+            f = open(dictionary)
+            f.seek(0,2)
+            DICT_FILESIZE = f.tell()
+            f.close()
+            if DICT_FILESIZE < 1000000:
+                with open(dictionary) as dictionary:
+                    DICT_CACHE = [smart_text(x.strip()) for x in dictionary.readlines()]
+                    return DICT_CACHE
         with open(dictionary) as dictionary:
             return [smart_text(x.strip()) for x in dictionary.readlines()]
 


### PR DESCRIPTION
This PR adds some simple dictionary buffering for better performance with small dicts. The cache size has be arbitrarily chosen to the 1000000 bytes (1MB).

This should address performance issues
ex.
https://github.com/dstufft/django-passwords/issues/3