### PR TITLE
Update python and django version coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,10 @@
 language: python
 python:
 - '2.7'
-- '3.4'
-- '3.5'
+- '3.6'
 env:
-- DJANGO="django>=1.3,<1.4"
-- DJANGO="django>=1.4,<1.5"
-- DJANGO="django>=1.5,<1.6"
-- DJANGO="django>=1.6,<1.7"
-- DJANGO="django>=1.7,<1.8"
-- DJANGO="django>=1.8,<1.9"
-- DJANGO="django>=1.9,<1.10"
+- DJANGO="django>=1.11,<2.0"
+- DJANGO="django>=2.0,<3.0"
 install:
 - pip install -r requirements/test.txt
 - pip install coverage coveralls
@@ -19,24 +13,10 @@ script:
 - py.test tests --cov passwords
 matrix:
   exclude:
-  - python: '3.4'
-    env: DJANGO="django>=1.3,<1.4"
-  - python: '3.4'
-    env: DJANGO="django>=1.4,<1.5"
-  - python: '3.4'
-    env: DJANGO="django>=1.5,<1.6"
-  - python: '3.4'
-    env: DJANGO="django>=1.6,<1.7"
-  - python: '3.5'
-    env: DJANGO="django>=1.3,<1.4"
-  - python: '3.5'
-    env: DJANGO="django>=1.4,<1.5"
-  - python: '3.5'
-    env: DJANGO="django>=1.5,<1.6"
-  - python: '3.5'
-    env: DJANGO="django>=1.6,<1.7"
-  - python: '3.5'
-    env: DJANGO="django>=1.7,<1.8"
+  - python: '2.7'
+    env: DJANGO="django>=2.0,<3.0"
+  - python: '3.6'
+    env: DJANGO="django>=1.11,<2.0"
 after_success:
 - coverage report
 - coveralls

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,5 @@
-coverage==4.0.1
-flake8==2.4.1
+coverage==5.0.3
+flake8==3.7.9
 pytest-cov==2.2.0
-pytest==2.8.0
-tox==2.1.1
+pytest==2.8.1
+tox==3.14.5

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from django.core.exceptions import ValidationError
 from passwords import validators
 from unittest import TestCase
+from six import assertRaisesRegex
 
 
 class TestLengthValidatorTests(TestCase):
@@ -68,7 +69,7 @@ class ValidatorTestCase(TestCase):
             with self.assertRaises(ValidationError):
                 validator(string)
         else:
-            with self.assertRaisesRegexp(ValidationError, exc_re):
+            with assertRaisesRegex(self, ValidationError, exc_re):
                 validator(string)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,8 @@ envlist =
     py27-dj{13,14,15,16,17,18,19},
     py34-dj{15,16,17,18,19}
     py35-dj{17,18,19}
+    py36-dj{17,18,19,22}
+    py37-dj{17,18,19,22}
 
 [testenv]
 commands = py.test tests
@@ -15,3 +17,4 @@ deps =
     dj17: Django>=1.7,<1.8
     dj18: Django>=1.8,<1.9
     dj19: Django==1.9rc1
+    dj22: Django==2.2


### PR DESCRIPTION
Update regex due to deprication warning
This adds the use of six to maintain py2 compatability