### PR TITLE
Revert "Merge pull request #56 from darakian/buffer-small-dicts"

### DIFF
--- a/passwords/validators.py
+++ b/passwords/validators.py
@@ -23,9 +23,6 @@ COMMON_SEQUENCES = [
     "qwertzuiopü*asdfghjklöä'>yxcvbnm;:_",
     "qaywsxedcrfvtgbzhnujmikolp",
 ]
-DICT_CACHE = []
-DICT_FILESIZE = -1
-DICT_MAX_CACHE = 1000000
 
 # Settings
 PASSWORD_MIN_LENGTH = getattr(
@@ -179,17 +176,6 @@ class DictionaryValidator(BaseSimilarityValidator):
             threshold=threshold)
 
     def get_dictionary_words(self, dictionary):
-        if DICT_CACHE:
-            return DICT_CACHE
-        if DICT_FILESIZE is -1:
-            f = open(dictionary)
-            f.seek(0,2)
-            DICT_FILESIZE = f.tell()
-            f.close()
-            if DICT_FILESIZE < 1000000:
-                with open(dictionary) as dictionary:
-                    DICT_CACHE = [smart_str(x.strip()) for x in dictionary.readlines()]
-                    return DICT_CACHE
         with open(dictionary) as dictionary:
             return [smart_str(x.strip()) for x in dictionary.readlines()]
 


### PR DESCRIPTION
This reverts commit fe8505091fc24fa7b8d4a22b36bf9b8f0a931430, reversing changes made to bdb0e991ca0cf0996e8b681ff7745cf729900f48.

---

Reverting this primarily because it does not appear to work - if I install the `master` branch of this library and try to use this code in my project, I get this error:

```
UnboundLocalError: local variable 'DICT_CACHE' referenced before assignment
```

This is because `DICT_CACHE` is defined as a global variable but is then being accessed and modified within this method, which creates a local variable within the scope of this method that shadows the global with the same name, and this local variable is then not yet defined at the point it is being used. See https://docs.python.org/3/faq/programming.html#why-am-i-getting-an-unboundlocalerror-when-the-variable-has-a-value.

Given this, adding `global DICT_CACHE` to this method does fix this, however I then see this similar error:

```
UnboundLocalError: local variable 'DICT_FILESIZE' referenced before assignment
```

Similarly, adding `global DICT_CACHE, DICT_FILESIZE` fixes this, and the code then does appear to run without errors.

However the fact these issues existed just running the code makes me question how well it has been tested and whether it actually works as intended or addresses the original issue even with these amendments. It is not covered by any automated tests, which I assume is partly how this issue went unnoticed for so long (over 2 years since this was merged).

I can only assume the other aspect which made this go unnoticed is that this code is not yet present in a release, and the error would only occur if someone was specifically using `DictionaryValidator`, and so someone would need to install directly from `master` and then try to use this validator for this to occur - which must have not happened until I just did this (or at least not been reported!). There has been no recent change to how this aspect of Python scoping works that I can see that would effect whether this code causes these errors (so I don't think this is just because I'm using a more recent version of Python).

Given the above, it seems safest to revert this change until we can ensure a working, tested version of this code that addresses the original issue is created.

---

cc @darakian in case I'm missing something here