### PR TITLE
Improve build and bump supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,24 @@
+dist: focal
 language: python
 python:
-- '2.7'
-- '3.6'
-env:
-- DJANGO="django>=1.11,<2.0"
-- DJANGO="django>=2.0,<3.0"
+  - "3.7"
+  - "3.8"
+  - "3.9"
+  - "3.10"
 install:
-- pip install -r requirements/test.txt
-- pip install coverage coveralls
-- pip install $DJANGO
+  - pip install -r requirements/test.txt
 script:
-- py.test tests --cov passwords
-matrix:
-  exclude:
-  - python: '2.7'
-    env: DJANGO="django>=2.0,<3.0"
-  - python: '3.6'
-    env: DJANGO="django>=1.11,<2.0"
+  # Convert Travis Python version, as above, to first part of Tox environment
+  # name, and then run tests for each supported Django version in each
+  # environment - adapted from https://stackoverflow.com/a/42309035/2620402.
+  - tox -l | grep $(echo py$TRAVIS_PYTHON_VERSION | tr -d .) | xargs -n1 tox -e
 after_success:
-- coverage report
-- coveralls
+  - coverage report
+  - coveralls
 notifications:
   email:
     recipients:
-    - maccesch@web.de
+      - maccesch@web.de
 deploy:
   provider: pypi
   user: maccesch

--- a/README.rst
+++ b/README.rst
@@ -32,8 +32,8 @@ Or manually by downloading a tarball and typing::
 Compatibility
 -------------
 
-django-passwords is compatible with Django 1.3 through 1.9 RC1. Pythons 2.7
-and 3.4 are both supported.
+django-passwords is compatible with Django 2.2, 3.2, and 4.0. Pythons 3.7
+through 3.10 are supported.
 
 Settings
 --------

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,6 @@
-coverage==5.0.3
-flake8==3.7.9
-pytest-cov==2.2.0
-pytest==2.8.1
-tox==3.14.5
+coverage==6.3.2
+coveralls==3.3.1
+flake8==4.0.1
+pytest-cov==3.0.0
+pytest==7.1.1
+tox==3.24.5

--- a/setup.py
+++ b/setup.py
@@ -14,19 +14,19 @@ setup(
         "passwords",
     ],
     include_package_data=True,
-    install_requires = [
-        "Django >= 1.3",
+    install_requires=[
+        "Django >= 2.2",
     ],
-    classifiers = [
+    classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Web Environment",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 2.6",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Utilities",
         "Framework :: Django",
     ],

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from django.core.exceptions import ValidationError
 from passwords import validators
 from unittest import TestCase
+from tempfile import NamedTemporaryFile
 
 
 class TestLengthValidatorTests(TestCase):
@@ -223,11 +224,17 @@ class DictionaryValidator(ValidatorTestCase):
     same = 'words'
 
     def mkvalidator(self, words=None, dictionary_words=None, threshold=None):
+        dictionary = None
+        if dictionary_words:
+            dictionary_file = NamedTemporaryFile(mode='w')
+            dictionary_file.write(dictionary_words)
+            dictionary = dictionary_file.name
+
         instance = validators.DictionaryValidator(
             words=words,
-            threshold=threshold)
-        if dictionary_words:
-            instance.get_dictionary_words = lambda self, d: dictionary_words
+            threshold=threshold,
+            dictionary=dictionary
+        )
         return instance
 
     def test_provide_words_but_no_dictionary(self):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 from django.core.exceptions import ValidationError
 from passwords import validators
 from unittest import TestCase
-from six import assertRaisesRegex
 
 
 class TestLengthValidatorTests(TestCase):
@@ -69,7 +68,7 @@ class ValidatorTestCase(TestCase):
             with self.assertRaises(ValidationError):
                 validator(string)
         else:
-            with assertRaisesRegex(self, ValidationError, exc_re):
+            with self.assertRaisesRegex(ValidationError, exc_re):
                 validator(string)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,14 @@
 [tox]
 envlist =
-    py27-dj{13,14,15,16,17,18,19},
-    py34-dj{15,16,17,18,19}
-    py35-dj{17,18,19}
-    py36-dj{17,18,19,22}
-    py37-dj{17,18,19,22}
+    py37-dj{22,32}
+    py38-dj{22,32,40}
+    py39-dj{22,32,40}
+    py310-dj{32,40}
 
 [testenv]
-commands = py.test tests
+commands = py.test tests --cov passwords
+install_command = python -m pip install -r requirements/test.txt {packages}
 deps =
-    pytest
-    dj13: Django>=1.3,<1.4
-    dj14: Django>=1.4,<1.5
-    dj15: Django>=1.5,<1.6
-    dj16: Django>=1.6,<1.7
-    dj17: Django>=1.7,<1.8
-    dj18: Django>=1.8,<1.9
-    dj19: Django==1.9rc1
     dj22: Django==2.2
+    dj32: Django==3.2
+    dj40: Django==4.0


### PR DESCRIPTION
This PR improves and fixes the testing/build setup, and updates the supported Python/Django versions to those that are currently maintained. I made these changes as part of investigating the issue in https://github.com/dstufft/django-passwords/pull/65, as well as confirming to my satisfaction that this library works on more recent Python/Django versions as part of updating my own project. See each commit and the inline comments for full details of the changes being made and why.

You can see an example build for these changes, with https://github.com/dstufft/django-passwords/pull/65 merged as well (otherwise tests would fail), here: https://app.travis-ci.com/github/bobwhitelock/django-passwords/builds/248969588